### PR TITLE
Retain formats of empty line

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -5,7 +5,7 @@ import {
   EmbedBlot,
   LeafBlot,
   Scope,
-} from 'parchment';
+} from '@creately/parchment';
 import Break from './break';
 import Inline from './inline';
 import TextBlot from './text';
@@ -114,7 +114,7 @@ class Block extends BlockBlot {
      * This is a tempory change to fix following 
      * 1. Can't add multuple new lines without losing the format.
      * 2. When setting content, the new lines are always formatless.
-     * 3. Deleting a line should not result in clearing it's formats.
+     * 3. Deleting a line should not result in clearing it's formats. => Fixed in parchment as permenent
      * 4. Cursor height / line height should be consistent unless user change formatting.
      * 
      * In super method default blot ("BR") is appended if this blot is empty.
@@ -123,6 +123,16 @@ class Block extends BlockBlot {
      * a sperate child class should be added for "P" block and do this change
      */
     try {
+      if(this.domNode.innerText === '' && this.children.length !== 0){
+        const leafBlot = getDescendentsOfLeafBlot(this)[0];
+        const lastElementBlot = leafBlot.parent;
+        if (leafBlot instanceof TextBlot) {
+          leafBlot.remove();
+          const child = this.scroll.create(Break.blotName);
+          lastElementBlot.appendChild(child);
+        }
+      }
+
       if( this.isFormatlessEmptyP( this.domNode )) {
         let formatNode;
         if ( this.prev && !this.isFormatlessEmptyP( this.prev.domNode )) {
@@ -268,8 +278,7 @@ BlockEmbed.scope = Scope.BLOCK_BLOT;
 // It is important for cursor behavior BlockEmbeds use tags that are block level elements
 
 function blockDelta(blot, filter = true) {
-  return blot
-    .descendants(LeafBlot)
+  return getDescendentsOfLeafBlot(blot)
     .reduce((delta, leaf) => {
       if (leaf.length() === 0) {
         return delta;
@@ -299,6 +308,13 @@ function bubbleFormats(blot, formats = {}, filter = true) {
     return formats;
   }
   return bubbleFormats(blot.parent, formats, filter);
+}
+
+function getDescendentsOfLeafBlot (blot) {
+  if(!blot){
+    return;
+  }
+  return blot.descendants(LeafBlot);
 }
 
 export { blockDelta, bubbleFormats, BlockEmbed, Block as default };

--- a/blots/break.js
+++ b/blots/break.js
@@ -1,4 +1,4 @@
-import { EmbedBlot } from 'parchment';
+import { EmbedBlot } from '@creately/parchment';
 
 class Break extends EmbedBlot {
   static value() {

--- a/blots/container.js
+++ b/blots/container.js
@@ -1,4 +1,4 @@
-import { ContainerBlot } from 'parchment';
+import { ContainerBlot } from '@creately/parchment';
 
 class Container extends ContainerBlot {}
 

--- a/blots/cursor.js
+++ b/blots/cursor.js
@@ -1,4 +1,4 @@
-import { EmbedBlot, Scope } from 'parchment';
+import { EmbedBlot, Scope } from '@creately/parchment';
 import TextBlot from './text';
 
 class Cursor extends EmbedBlot {

--- a/blots/embed.js
+++ b/blots/embed.js
@@ -1,4 +1,4 @@
-import { EmbedBlot } from 'parchment';
+import { EmbedBlot } from '@creately/parchment';
 import TextBlot from './text';
 
 const GUARD_TEXT = '\uFEFF';

--- a/blots/inline.js
+++ b/blots/inline.js
@@ -1,4 +1,4 @@
-import { EmbedBlot, InlineBlot, Scope } from 'parchment';
+import { EmbedBlot, InlineBlot, Scope } from '@creately/parchment';
 import Break from './break';
 import Text from './text';
 

--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -1,4 +1,4 @@
-import { Scope, ScrollBlot, ContainerBlot } from 'parchment';
+import { Scope, ScrollBlot, ContainerBlot } from '@creately/parchment';
 import Emitter from '../core/emitter';
 import Block, { BlockEmbed } from './block';
 import Break from './break';

--- a/blots/text.js
+++ b/blots/text.js
@@ -1,4 +1,4 @@
-import { TextBlot } from 'parchment';
+import { TextBlot } from '@creately/parchment';
 
 class Text extends TextBlot {}
 

--- a/core/editor.js
+++ b/core/editor.js
@@ -2,7 +2,7 @@ import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import merge from 'lodash.merge';
 import Delta, { AttributeMap } from 'quill-delta';
-import { LeafBlot } from 'parchment';
+import { LeafBlot } from '@creately/parchment';
 import { Range } from './selection';
 import CursorBlot from '../blots/cursor';
 import Block, { BlockEmbed, bubbleFormats } from '../blots/block';

--- a/core/quill.js
+++ b/core/quill.js
@@ -1,7 +1,7 @@
 import Delta from 'quill-delta';
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
-import * as Parchment from 'parchment';
+import * as Parchment from '@creately/parchment';
 import Editor from './editor';
 import Emitter from './emitter';
 import Module from './module';

--- a/core/selection.js
+++ b/core/selection.js
@@ -1,4 +1,4 @@
-import { LeafBlot, Scope } from 'parchment';
+import { LeafBlot, Scope } from '@creately/parchment';
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import Emitter from './emitter';

--- a/formats/align.js
+++ b/formats/align.js
@@ -1,4 +1,4 @@
-import { Attributor, ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { Attributor, ClassAttributor, Scope, StyleAttributor } from '@creately/parchment';
 
 const config = {
   scope: Scope.BLOCK,

--- a/formats/background.js
+++ b/formats/background.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope } from 'parchment';
+import { ClassAttributor, Scope } from '@creately/parchment';
 import { ColorAttributor } from './color';
 
 const BackgroundClass = new ClassAttributor('background', 'ql-bg', {

--- a/formats/color.js
+++ b/formats/color.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { ClassAttributor, Scope, StyleAttributor } from '@creately/parchment';
 
 class ColorAttributor extends StyleAttributor {
   value(domNode) {

--- a/formats/direction.js
+++ b/formats/direction.js
@@ -1,4 +1,4 @@
-import { Attributor, ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { Attributor, ClassAttributor, Scope, StyleAttributor } from '@creately/parchment';
 
 const config = {
   scope: Scope.BLOCK,

--- a/formats/font.js
+++ b/formats/font.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { ClassAttributor, Scope, StyleAttributor } from '@creately/parchment';
 
 const config = {
   scope: Scope.INLINE,

--- a/formats/image.js
+++ b/formats/image.js
@@ -1,4 +1,4 @@
-import { EmbedBlot } from 'parchment';
+import { EmbedBlot } from '@creately/parchment';
 import { sanitize } from './link';
 
 const ATTRIBUTES = ['alt', 'height', 'width'];

--- a/formats/indent.js
+++ b/formats/indent.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope } from 'parchment';
+import { ClassAttributor, Scope } from '@creately/parchment';
 
 class IndentAttributor extends ClassAttributor {
   add(node, value) {

--- a/formats/size.js
+++ b/formats/size.js
@@ -1,4 +1,4 @@
-import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
+import { ClassAttributor, Scope, StyleAttributor } from '@creately/parchment';
 
 const SizeClass = new ClassAttributor('size', 'ql-size', {
   scope: Scope.INLINE,

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -6,7 +6,7 @@ import {
   Scope,
   StyleAttributor,
   BlockBlot,
-} from 'parchment';
+} from '@creately/parchment';
 import { BlockEmbed } from '../blots/block';
 import Quill from '../core/quill';
 import logger from '../core/logger';

--- a/modules/history.js
+++ b/modules/history.js
@@ -1,4 +1,4 @@
-import { Scope } from 'parchment';
+import { Scope } from '@creately/parchment';
 import Quill from '../core/quill';
 import Module from '../core/module';
 

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 import Delta, { AttributeMap } from 'quill-delta';
-import { EmbedBlot, Scope, TextBlot } from 'parchment';
+import { EmbedBlot, Scope, TextBlot } from '@creately/parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -1,5 +1,5 @@
 import Delta from 'quill-delta';
-import { ClassAttributor, Scope } from 'parchment';
+import { ClassAttributor, Scope } from '@creately/parchment';
 import Inline from '../blots/inline';
 import Quill from '../core/quill';
 import Module from '../core/module';

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -1,5 +1,5 @@
 import Delta from 'quill-delta';
-import { EmbedBlot, Scope } from 'parchment';
+import { EmbedBlot, Scope } from '@creately/parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creately/quill",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Your powerful, rich text editor",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
@@ -36,7 +36,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.5.0",
-    "parchment": "2.0.0-dev.2",
+    "@creately/parchment": "^1.0.0",
     "quill-delta": "4.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
favro: [https://favro.com/organization/c9668dc39f1bd49fed254201/6a932da5a9e16600f2a20ca3?card=Cre-9406](https://favro.com/organization/c9668dc39f1bd49fed254201/6a932da5a9e16600f2a20ca3?card=Cre-9406)

**This Fix has multiple pull requests. For creately/quillonly this PR.**
**First PR is :** [https://github.com/creately/parchment/pull/3](https://github.com/creately/parchment/pull/3)

**Changes Summary:**
- `blots/block.js` (`Block` class) optimize function added code block to check if line text is empty and children length > 0 then, first text node is removed and add `Break` `<br>` to style element as placeholder.
- Change import from `parchment` to `@creately/parchment`